### PR TITLE
#167750055 Build out Reset password Endpoints for Users

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,5 @@
+version: "2"
+exclude_patterns:
+  - "/database/"
+  - "/models/"
+  - "**/test/"

--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,6 @@ yarn-debug.log*
 yarn-error.log*
 lerna-debug.log*
 
-package-lock.json
 
 # Diagnostic reports (https://nodejs.org/api/report.html)
 report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
@@ -49,8 +48,6 @@ build/Release
 node_modules/
 jspm_packages/
 
-#node lock file
-package-lock.json
 
 # TypeScript v1 declaration files
 typings/

--- a/package-lock.json
+++ b/package-lock.json
@@ -2995,7 +2995,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3016,12 +3017,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3036,17 +3039,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3163,7 +3169,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3175,6 +3182,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3189,6 +3197,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3196,12 +3205,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3220,6 +3231,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3300,7 +3312,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3312,6 +3325,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3397,7 +3411,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3433,6 +3448,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3452,6 +3468,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3495,12 +3512,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -6161,9 +6180,9 @@
       }
     },
     "regexp-tree": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.12.tgz",
-      "integrity": "sha512-TsXZ8+cv2uxMEkLfgwO0E068gsNMLfuYwMMhiUxf0Kw2Vcgzq93vgl6wIlIYuPmfMqMjfQ9zAporiozqCnwLuQ==",
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.11.tgz",
+      "integrity": "sha512-7/l/DgapVVDzZobwMCCgMlqiqyLFJ0cduo/j+3BcDJIB+yJdsYCfKuI3l/04NV+H/rfNRdPIDbXNZHM9XvQatg==",
       "dev": true
     },
     "regexpp": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "undo-migrate": "node_modules/.bin/sequelize db:migrate:undo:all",
     "seed": "node_modules/.bin/sequelize db:seed:all",
     "undo-seed": "node_modules/.bin/sequelize db:seed:undo:all",
-    "drop-db": "node_modules/.bin/sequelize db:drop"
+    "drop-db": "node_modules/.bin/sequelize db:drop",
+    "lint": "node_modules/.bin/eslint --fix src/**/*.js"
   },
   "author": "Andela Simulations Programme",
   "license": "MIT",
@@ -24,7 +25,7 @@
     "dotenv": "^6.2.0",
     "express": "^4.16.3",
     "express-validator": "^6.1.1",
-    "jsonwebtoken": "^8.3.0",
+    "jsonwebtoken": "^8.5.1",
     "passport": "^0.4.0",
     "passport-facebook": "^3.0.0",
     "passport-google-oauth": "^2.0.0",

--- a/scripts/install-hooks.bash
+++ b/scripts/install-hooks.bash
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+GIT_DIR=$(git rev-parse --git-dir)
+
+echo "Installing hooks..."
+# this command creates symlink to our pre-commit script
+ln -s ../../scripts/pre-commit.bash $GIT_DIR/hooks/pre-commit
+ln -s ../../scripts/pre-push.bash $GIT_DIR/hooks/pre-push
+echo "Done!"

--- a/scripts/pre-commit.bash
+++ b/scripts/pre-commit.bash
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+echo "Running pre-commit hook"
+./scripts/run-eslint.bash
+
+# $? stores exit value of the last command
+if [ $? -ne 0 ]; then
+ echo "Linting errors must be fixed before commit!"
+ exit 1
+fi

--- a/scripts/pre-push.bash
+++ b/scripts/pre-push.bash
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+echo "Running pre-push hook"
+./scripts/run-eslint.bash
+
+# $? stores exit value of the last command
+if [ $? -ne 0 ]; then
+ echo "Please fix all linting errors before pushing!"
+ exit 1
+fi
+
+./scripts/run-tests.bash
+
+if [ $? -ne 0 ]; then
+ echo "All tests must pass before pushing!"
+ exit 1
+fi

--- a/scripts/run-eslint.bash
+++ b/scripts/run-eslint.bash
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+# if any command inside script returns error, exit and return that error 
+set -e
+
+# magic line to ensure that we're always inside the root of our application,
+# no matter from which directory we'll run script
+# thanks to it we can just enter `./scripts/run-tests.bash`
+cd "${0%/*}/.."
+
+# let's fake failing test for now 
+echo "Running eslint"
+echo "............................" 
+# echo "Failed!" && exit 1
+
+# example of commands for different languages
+# eslint .         # JS code quality check
+# npm test         # JS unit tests
+# flake8 .         # python code quality check
+# nosetests        # python nose 
+# just put your usual test command here 
+# npm test
+npm run lint
+

--- a/scripts/run-tests.bash
+++ b/scripts/run-tests.bash
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+# if any command inside script returns error, exit and return that error 
+set -e
+
+# magic line to ensure that we're always inside the root of our application,
+# no matter from which directory we'll run script
+# thanks to it we can just enter `./scripts/run-tests.bash`
+cd "${0%/*}/.."
+
+# let's fake failing test for now 
+echo "Running tests"
+echo "............................" 
+# echo "Failed!" && exit 1
+
+# example of commands for different languages
+# eslint .         # JS code quality check
+# npm test         # JS unit tests
+# flake8 .         # python code quality check
+# nosetests        # python nose 
+# just put your usual test command here 
+# npm test
+npm test
+

--- a/src/controllers/authController.js
+++ b/src/controllers/authController.js
@@ -1,5 +1,5 @@
 import passport from 'passport';
-import { generateUserToken } from '../utils';
+import { generateToken } from '../utils';
 import passportConfIgnored from '../config/passport';
 
 /**
@@ -18,7 +18,8 @@ export const callback = provider => (req, res, next) => {
       if (err || !user) return res.status(500).json({ status: 500, message: 'Registration unsuccessful. Please try again later.' });
       
       // process successfully authenticated and registered user
-      const token = generateUserToken(user);
+      const { id: userId } = user;
+      const token = generateToken({ userId });
       res.status(res.statusCode).json({ status: res.statusCode, token });
     }
   )(req, res, next);

--- a/src/controllers/index.js
+++ b/src/controllers/index.js
@@ -1,3 +1,5 @@
-import registerUser from './users';
+import UsersController from './users';
+import ResetPasswordController from './resetPassword';
 
-export default registerUser;
+
+export { UsersController, ResetPasswordController };

--- a/src/controllers/users.js
+++ b/src/controllers/users.js
@@ -1,29 +1,41 @@
 
 import models from '../models';
 import {
-  status, messages, hashPassword, generateUserToken,
+  status, messages, hashPassword, generateToken,
   successResponse, errorResponse, conflictResponse
 } from '../utils/index';
 
-const registerUser = async (req, res) => {
-  try {
-    const { email } = req.body;
-    const userExits = await models.Users.findOne({ where: { email } });
-    if (userExits) {
-      return conflictResponse(res, status.conflict, messages.signUp.conflict);
+/**
+ * @class UserController
+ * @description Controllers for Users
+ * @exports UsersController
+ */
+export default class UsersController {
+  /**
+   * @method registerUser
+   * @description Method for user registration
+   * @param {object} req - The Request Object
+   * @param {object} res - The Response Object
+   * @returns {object} response body object
+   */
+  static async registerUser(req, res) {
+    try {
+      const { email } = req.body;
+      const userExits = await models.Users.findOne({ where: { email } });
+      if (userExits) {
+        return conflictResponse(res, status.conflict, messages.signUp.conflict);
+      }
+
+      req.body.password = await hashPassword(req.body.password);
+      const user = await models.Users.create(req.body);
+      const response = user.toJSON();
+
+      delete response.password;
+      const { id: userId } = user;
+      const token = await generateToken({ userId });
+      return successResponse(res, status.created, messages.signUp.success, response, token);
+    } catch (error) {
+      return errorResponse(res, status.error, messages.signUp.error);
     }
-
-    req.body.password = await hashPassword(req.body.password);
-    const user = await models.Users.create(req.body);
-    const response = user.toJSON();
-
-    delete response.password;
-
-    const token = generateUserToken(user);
-    return successResponse(res, status.created, messages.signUp.success, response, token);
-  } catch (error) {
-    return errorResponse(res, status.error, messages.signUp.error);
   }
-};
-
-export default registerUser;
+}

--- a/src/database/seeders/user.js
+++ b/src/database/seeders/user.js
@@ -1,3 +1,4 @@
+
 export default {
   up: queryInterface => queryInterface.bulkInsert(
     'Users',
@@ -9,6 +10,18 @@ export default {
         password: 'funmi',
         createdAt: new Date(),
         updatedAt: new Date()
+      },
+      {
+        email: 'adelekegbolahan92@yahoo.com',
+        password: 'Anonymous',
+        createdAt: new Date(),
+        updatedAt: new Date()
+      },
+      {
+        password: 'Unkown',
+        email: 'janedoe@example.com',
+        createdAt: new Date(),
+        updatedAt: new Date(),
       }
     ],
     {}

--- a/src/index.js
+++ b/src/index.js
@@ -16,7 +16,7 @@ app.use(express.json());
 
 const isProduction = process.env.NODE_ENV === 'production';
 
-// Test route
+
 app.get('/', (req, res) => res.json({ status: res.statusCode, message: 'Welcome to Wolfsbane' }));
 
 app.use(router);

--- a/src/routes/api/index.js
+++ b/src/routes/api/index.js
@@ -1,13 +1,12 @@
 import express from 'express';
 import userRoute from './users';
 import authRoutes from './auth';
+import resetPasswordRoute from './resetPassword';
 
 const router = express.Router();
 
-router.get('/', (req, res) => {
-  res.status(200).json({ message: 'Welcome to wolfsbane server' });
-});
-router.use('/', userRoute);
 router.use('/auth', authRoutes);
+router.use('/users', userRoute);
+router.use('/', resetPasswordRoute);
 
 export default router;

--- a/src/routes/api/resetPassword.js
+++ b/src/routes/api/resetPassword.js
@@ -1,0 +1,15 @@
+import { Router } from 'express';
+import middlewares from '../../middlewares';
+import ResetPasswordController from '../../controllers/resetPassword';
+
+const {
+  sendPasswordResetEmail,
+  setNewPassword
+} = ResetPasswordController;
+const { validate } = middlewares;
+
+const resetPasswordRoutes = new Router();
+resetPasswordRoutes.post('/forgotpassword', validate('forgotPassword'), sendPasswordResetEmail);
+resetPasswordRoutes.post('/resetpassword/:userId', validate('resetPassword'), setNewPassword);
+
+export default resetPasswordRoutes;

--- a/src/routes/api/users.js
+++ b/src/routes/api/users.js
@@ -1,11 +1,12 @@
 import express from 'express';
 import middlewares from '../../middlewares';
-import registerUser from '../../controllers';
+import { UsersController } from '../../controllers';
 
 const { validate } = middlewares;
+const { registerUser } = UsersController;
 
 const router = express.Router();
 
-router.post('/users/signup', validate('userRegister'), registerUser);
+router.post('/signup', validate('userRegister'), registerUser);
 
 export default router;

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -1,7 +1,8 @@
-import express from 'express';
+import { Router } from 'express';
 import api from './api';
 
-const router = express.Router();
+
+const router = new Router();
 
 router.use('/api/v1', api);
 

--- a/src/test/base-route/base-route.test.js
+++ b/src/test/base-route/base-route.test.js
@@ -6,7 +6,7 @@ import { status } from '../../utils';
 chai.use(chaiHttp);
 chai.should();
 
-const entryRoute = '/api/v1';
+const entryRoute = '/';
 
 // Base Route Test
 describe('Base Route Test ', () => {
@@ -14,7 +14,7 @@ describe('Base Route Test ', () => {
     chai.request(server).get(entryRoute).end((error, response) => {
       if (error) throw Error(`Error making test request ${entryRoute}`);
       response.should.have.status(status.success);
-      response.body.message.should.equal('Welcome to wolfsbane server');
+      response.body.message.should.equal('Welcome to Wolfsbane');
       done();
     });
   });

--- a/src/test/controllers/resetpassword.test.js
+++ b/src/test/controllers/resetpassword.test.js
@@ -1,0 +1,173 @@
+import chai from 'chai';
+import chaiHttp from 'chai-http';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import app from '../../index';
+import models from '../../models';
+import ResetPasswordController from '../../controllers/resetPassword';
+import { Jwt } from '../../utils';
+
+
+const { expect } = chai;
+chai.use(chaiHttp);
+chai.use(sinonChai);
+
+let request;
+describe('RESET PASSWORD', () => {
+  before(async () => {
+    request = chai.request(app).keepOpen();
+  });
+
+  afterEach(() => sinon.restore());
+
+  after(() => request.close());
+
+  context('FORGOT PASSWORD', () => {
+    it('should have a status 200 and send password reset link to the supplied email', async () => {
+      const req = {
+        body: {
+          email: 'fakemail@mail.com'
+        },
+        headers: {
+          host: 'barefootNomad.heroku.com'
+        }
+      };
+      const res = {
+        status: () => {},
+        json: () => {}
+      };
+      const user = {
+        id: 'ksd095',
+        email: 'fakemail@mail.com',
+        password: '9ijk3632',
+        createdAt: '2010/10/10'
+      };
+      sinon.stub(res, 'status').returnsThis();
+      sinon.stub(models.Users, 'findOne').returns(user);
+
+      await ResetPasswordController.sendPasswordResetEmail(req, res);
+      expect(res.status).to.have.been.calledWith(200);
+    });
+    it('fakes user not found error for sending reset link to user email', async () => {
+      const req = {
+        body: {
+          email: 'fakemail@mail.com'
+        }
+      };
+      const res = {
+        status: () => {},
+        json: () => {},
+      };
+      sinon.stub(res, 'status').returnsThis();
+      sinon.stub(models.Users, 'findOne').returns(null);
+
+      await ResetPasswordController.sendPasswordResetEmail(req, res);
+      expect(res.status).to.have.been.calledWith(404);
+    });
+    it('should have a status 422 and return validation errors', async () => {
+      const badEmail = {
+        email: 'UzumakiNaruto.com'
+      };
+      const res = await request
+        .post('/api/v1/forgotpassword')
+        .send(badEmail);
+      expect(res).to.have.status(422);
+      expect(res.body).to.have.property('errors');
+    });
+    it('fakes server error setting reset password link', async () => {
+      const req = {
+        body: {
+          email: 'fakemail@mail.com'
+        }
+      };
+      const res = {
+        status: () => {},
+        json: () => {},
+      };
+      sinon.stub(res, 'status').returnsThis();
+      sinon.stub(models.Users, 'findOne').throws();
+
+      await ResetPasswordController.sendPasswordResetEmail(req, res);
+      expect(res.status).to.have.been.calledWith(500);
+    });
+  });
+
+  context('SET NEW PASSWORD', () => {
+    const req = {
+      body: {
+        password: 'newpassword'
+      },
+      params: {
+        userId: 'ksd095'
+      },
+      query: {
+        token: '98092qnk0k0sdfskn43t9ndsjmjknsf'
+      }
+    };
+    it('fakes server error setting new password', async () => {
+      const res = {
+        status: () => {},
+        json: () => {},
+      };
+      sinon.stub(res, 'status').returnsThis();
+      sinon.stub(models.Users, 'findOne').throws();
+
+      await ResetPasswordController.setNewPassword(req, res);
+      expect(res.status).to.have.been.calledWith(403);
+    });
+    it('fakes password reset link invalid error', async () => {
+      const res = {
+        status: () => {},
+        json: () => {},
+      };
+      sinon.stub(res, 'status').returnsThis();
+      sinon.stub(res, 'json').returns('Password reset Link invalid');
+      sinon.stub(models.Users, 'findOne').returns(false);
+
+      await ResetPasswordController.setNewPassword(req, res);
+      expect(res.status).to.have.been.calledWith(403);
+    });
+    it('fakes a successful reset password change', async () => {
+      const res = {
+        status: () => {},
+        json: () => {},
+      };
+      const userData = {
+        dataValues: {
+          id: 'ksd095',
+          password: '9ijk3632',
+          createdAt: '2010/10/10'
+        }
+      };
+      sinon.stub(res, 'status').returnsThis();
+      sinon.stub(models.Users, 'findOne').returns(userData);
+      sinon.stub(Jwt, 'verifyToken').returns({ userId: 'ksd095' });
+      sinon.stub(models.Users, 'update').returns(true);
+
+      await ResetPasswordController.setNewPassword(req, res);
+      expect(res.status).to.have.been.calledWith(202);
+    });
+    it('should have a status 422 and return an error response', async () => {
+      const passwordReset = {
+        password: 'jackjones92',
+        confirmPassword: 'Jackjones92'
+      };
+      const res = await request
+        .post('/api/v1/resetpassword/klsdjkfmka?token=lkashvbnasjgpsojfas32509849')
+        .send(passwordReset);
+      expect(res).to.have.status(422);
+      expect(res.body).to.have.property('errors');
+    });
+    it('should have a pass validation and hit the controller', async () => {
+      const passwordReset = {
+        password: 'Jackjones92',
+        confirmPassword: 'Jackjones92'
+      };
+      const res = await request
+        .post('/api/v1/resetpassword/klsdjkfmka?token=lkashvbnasjgpsojfas32509849')
+        .send(passwordReset);
+      expect(res).to.have.status(403);
+      expect(res.body).to.have.property('message');
+    });
+  });
+});

--- a/src/test/controllers/users.test.js
+++ b/src/test/controllers/users.test.js
@@ -1,11 +1,18 @@
 import chai from 'chai';
 import chaiHttp from 'chai-http';
 import faker from 'faker';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
 import server from '../../index';
+import models from '../../models';
+import { UsersController } from '../../controllers';
 import { status, messages } from '../../utils';
 
+chai.use(sinonChai);
 chai.use(chaiHttp);
 chai.should();
+const { expect } = chai;
+const { registerUser } = UsersController;
 
 const signUpRoute = '/api/v1/users/signup';
 
@@ -88,5 +95,20 @@ describe('User Registration test', () => {
         res.body.should.have.property('message').eql(messages.signUp.conflict);
         done(err);
       });
+  });
+  afterEach(() => sinon.restore());
+  it('fakes a server error during user registration', async () => {
+    const req = {
+      body: dummyUser
+    };
+    const res = {
+      status: () => {},
+      json: () => {},
+    };
+    sinon.stub(res, 'status').returnsThis();
+    sinon.stub(models.Users, 'findOne').throws();
+
+    await registerUser(req, res);
+    expect(res.status).to.have.been.calledWith(500);
   });
 });

--- a/src/test/index.test.js
+++ b/src/test/index.test.js
@@ -1,6 +1,7 @@
 import './base-route/base-route.test';
 import './controllers/users.test';
 import './controllers/socialAuth.test';
+import './controllers/resetpassword.test';
 import './models/Department.test';
 import './models/Profile.test';
 import './models/Accomodation.test';
@@ -10,3 +11,6 @@ import './models/Room.test';
 import './models/Trip.test';
 import './models/User.test';
 import './validation/validate.test';
+import './utils/bcrypt.test';
+import './utils/responses.test';
+import './utils/jwt.test';

--- a/src/test/utils/bcrypt.test.js
+++ b/src/test/utils/bcrypt.test.js
@@ -1,0 +1,24 @@
+import chai from 'chai';
+
+import { hashPassword, comparePassword } from '../../utils';
+
+const { expect } = chai;
+
+describe('Brypt', () => {
+  const password = 'uthdev92';
+  let passwordHash;
+
+  context('generate Password hash', () => {
+    it('generate a new hash for the password', async () => {
+      passwordHash = hashPassword(password);
+      expect(passwordHash).to.be.a('string');
+    });
+  });
+
+  context('compare password with ', () => {
+    it('compare the password  with the hash', async () => {
+      const isMatch = comparePassword(passwordHash, password);
+      expect(isMatch).to.equal(true);
+    });
+  });
+});

--- a/src/test/utils/jwt.test.js
+++ b/src/test/utils/jwt.test.js
@@ -1,0 +1,23 @@
+import chai from 'chai';
+import { Jwt } from '../../utils';
+
+const { expect } = chai;
+
+describe('Jwt', () => {
+  const payload = { userId: 1 };
+  const secret = 'Sheesh!!! it is a secret';
+  let token;
+
+  context('generate token', () => {
+    it('return a generated token', async () => {
+      token = await Jwt.generateToken(payload, secret);
+      expect(token).to.be.a('string');
+    });
+  });
+  context('verify token', () => {
+    it('return a decoded payload', async () => {
+      const decoded = await Jwt.verifyToken(token, secret);
+      expect(decoded.userId).to.equal(payload.userId);
+    });
+  });
+});

--- a/src/test/utils/responses.test.js
+++ b/src/test/utils/responses.test.js
@@ -1,0 +1,39 @@
+import chai from 'chai';
+import chaiHttp from 'chai-http';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import { successResponse, errorResponse } from '../../utils';
+
+chai.use(chaiHttp);
+chai.use(sinonChai);
+const { expect } = chai;
+
+describe('Response Functions', () => {
+  afterEach(() => sinon.restore());
+
+  context('Error Response function', () => {
+    it('fakes a call to the error response', async () => {
+      const res = {
+        status: () => {},
+        json: () => {}
+      };
+      sinon.stub(res, 'status').returnsThis();
+
+      errorResponse(res, 404, 'Not found!');
+      expect(res.status).to.have.been.calledWith(404);
+    });
+  });
+
+  context('Success Response function', () => {
+    it('fakes a call to the success response', async () => {
+      const res = {
+        status: () => {},
+        json: () => {}
+      };
+      sinon.stub(res, 'status').returnsThis();
+
+      successResponse(res, 200, 'Success!');
+      expect(res.status).to.have.been.calledWith(200);
+    });
+  });
+});

--- a/src/utils/bcrypt.js
+++ b/src/utils/bcrypt.js
@@ -1,6 +1,5 @@
 /* eslint-disable camelcase */
 import bcrypt from 'bcrypt';
-import jwt from 'jsonwebtoken';
 /**
    * Hash Password Method
    * @param {string} password
@@ -18,21 +17,8 @@ const hashPassword = password => bcrypt.hashSync(password, salt);
    */
 const comparePassword = (hashedPassword, password) => bcrypt.compareSync(password, hashedPassword);
 
-/**
-   * Generate Token
-   * @param {string} id
-   * @returns {string} token
-   */
-const generateUserToken = ({ id }) => {
-  const token = jwt.sign({
-    userId: id
-  },
-  process.env.SECRET, { expiresIn: '3d' });
-  return token;
-};
 
 export {
   hashPassword,
-  comparePassword,
-  generateUserToken,
+  comparePassword
 };

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,14 +1,21 @@
-import { status, messages, successResponse, errorResponse, conflictResponse } from './responses';
-import { hashPassword, comparePassword, generateUserToken } from './token-password';
+import {
+  status, messages, successResponse, errorResponse, conflictResponse
+} from './responses';
+import { hashPassword, comparePassword } from './bcrypt';
+import Jwt from './jwt';
 import strategyCallback from './passportStrategyCallback';
 import getCallbackUrls from './getCallbackUrls';
 
+const { generateToken, verifyToken } = Jwt;
+
 export {
+  Jwt,
   status,
   messages,
   hashPassword,
+  generateToken,
+  verifyToken,
   comparePassword,
-  generateUserToken,
   successResponse,
   errorResponse,
   conflictResponse,

--- a/src/utils/jwt.js
+++ b/src/utils/jwt.js
@@ -1,0 +1,34 @@
+import jwt from 'jsonwebtoken';
+
+const secretKey = process.env.SECRET;
+
+/**
+ * @class Jwt
+ * @description class for token generation and verification
+ * @exports Jwt
+ */
+export default class Jwt {
+  /**
+   * @method generateToken
+   * @description Method to generate new token
+   * @param {object} payload - The data used to generate the token
+   * @param {string} secret - The secret key used to generate the token
+   * @returns {string} the generated token
+   */
+  static async generateToken(payload, secret = secretKey) {
+    const token = await jwt.sign(payload, secret, { expiresIn: '1d' });
+    return token;
+  }
+
+  /**
+   * @method verifyToken
+   * @description Method to decode the token
+   * @param {string} token - The token to be verified
+   * @param {string} secret - The secret key used to generate the token
+   * @returns {object} the payload decoded from the token
+   */
+  static async verifyToken(token, secret = secretKey) {
+    const decoded = await jwt.verify(token, secret);
+    return decoded;
+  }
+}

--- a/src/utils/passportStrategyCallback.js
+++ b/src/utils/passportStrategyCallback.js
@@ -1,6 +1,6 @@
 import models from '../models';
 import config from '../config';
-import { hashPassword } from './token-password';
+import { hashPassword } from './bcrypt';
 
 /**
    * It uses the done method to return an authenticated user or an error object

--- a/src/validation/index.js
+++ b/src/validation/index.js
@@ -1,9 +1,14 @@
-import { userRegister, userLogin } from './validators/rules';
+import {
+  userRegister, userLogin,
+  forgotPassword, resetPassword
+} from './validators/rules';
 
 const getValidator = (validationName) => {
   const rules = {
     userRegister,
-    userLogin
+    userLogin,
+    forgotPassword,
+    resetPassword
   };
 
   return rules[validationName];

--- a/src/validation/validators/rules.js
+++ b/src/validation/validators/rules.js
@@ -1,4 +1,4 @@
-import { check } from 'express-validator';
+import { check, body } from 'express-validator';
 
 // add validation rules here.
 
@@ -38,4 +38,21 @@ export const userLogin = [
     .isEmail()
     .not()
     .isEmpty()
+];
+
+export const forgotPassword = [
+  check('email', 'Please provide a valid email')
+    .isEmail()
+    .not()
+    .isEmpty()
+];
+
+export const resetPassword = [
+  check('password', 'password should be at least 6 characters').isLength({ min: 6 }),
+  body('confirmPassword').custom((value, { req }) => {
+    if (value !== req.body.password) {
+      throw new Error('Password confirmation does not match');
+    }
+    return true;
+  })
 ];


### PR DESCRIPTION
#### Description of Task to be completed?
 - write tests for the endpoints
 - Create an endpoint for sending a password reset email
 - create get endpoint for the password reset link
 - Create an endpoint for resetting the password by allowing a user to set a new password
 - Create client-side pre-commit and pre-push hooks
 #### How should this be manually tested?
- clone the repo
- cd into the root folder of the cloned repo
- run `npm install`  to install necessary dependencies
- run `npm run migrate` to create migrations
- run `npm run seed` to seed database with dummy users for test
- run `npm test` to run the test suite
- run `npm run start:dev` to start the server
- Go to Postman and make a POST request to `http://localhost:3000/api/v1/forgotpassword` sending `email: janedoe@example.com` in the request body
- You should get a link to reset user password if the user exists or an error otherwise
- Copy the link and make a POST request to the link sending the new password in the request body
- an appropriate response is sent to the user upon validation
- Run `./scripts/install-hooks.bash` to install the pre-commit and pre-push hooks
 #### Any background context you want to provide?
- Sample forgot password request
```
{
  "email": "fakemail@yahoo.com"
}
```
- Sample reset password request
```
{
  "password": "newPassword",
  "confirmPassword": "newPassword"
}
```
- The email sent in the request body is the seeded dummy user's email
- The link can only be used once to change password. Hence it becomes invalid after successful password reset
- The link sent expires in  a 24 hours period
 #### What are the relevant pivotal tracker stories?
[#167750055](https://www.pivotaltracker.com/story/show/167750055)
 #### Screenshots (if appropriate)
- Post endpoint for sending password reset email
![Screenshot (134)](https://user-images.githubusercontent.com/43517568/63439130-63e07800-c425-11e9-8ca0-2b552b8fddc1.png)
- Post endpoint for setting a new password
![Screenshot (136)](https://user-images.githubusercontent.com/43517568/63439658-6099bc00-c426-11e9-9357-a7a20c910068.png)
- An attempt to use the same link to change the password
![Screenshot (137)](https://user-images.githubusercontent.com/43517568/63439713-7a3b0380-c426-11e9-87dd-1b4f748f402d.png)
 #### Questions:
Based on my implementation, the user gets to see the password reset form upon validation from the backend. I wonder if this should have been left to be handled from the frontend?