### PR TITLE
#168325741 Fixes social authentication callback url bug

### DIFF
--- a/src/utils/getCallbackUrls.js
+++ b/src/utils/getCallbackUrls.js
@@ -3,18 +3,17 @@ import { config } from 'dotenv';
 config();
 const environment = process.env.NODE_ENV;
 const testEnvironment = !(environment === 'development' || environment === 'staging' || environment === 'production');
-const productionEnvironment = process.env.NODE_ENV === 'production';
-const stagingEnvironment = process.env.NODE_ENV === 'staging';
+const productionEnvironment = environment === 'production' || environment === 'staging';
 let baseUrl;
 
-if (productionEnvironment) baseUrl = 'barefootnomad.herokuapp.com/api/v1/auth';
-else if (stagingEnvironment) baseUrl = 'barefootnomad-staging.herokuapp.com/api/v1/auth';
+if (productionEnvironment) baseUrl = 'https://barefootnomad10-staging.herokuapp.com/api/v1/auth';
 else baseUrl = 'http://localhost:3000/api/v1/auth';
 
 const googleCallbackUrl = `${baseUrl}/google/callback`;
 const facebookCallbackUrl = `${baseUrl}/facebook/callback`;
 
 export default {
+  baseUrl,
   testEnvironment,
   googleCallbackUrl,
   facebookCallbackUrl


### PR DESCRIPTION
**What does this PR do?**
This PR fixes the url bug in the social authentication feature

**Description of tasks to be completed?**
- set the callback url to reflect the hosted app url

**How should this be manually tested/checked?**
This PR can only be tested after it is merged, from the hosted app on Heroku
1. In your browser, visit `https://barefootnomad10-staging.herokuapp.com/api/v1/auth/google`
2. It should take you to the Google consent page to login with your credentials
3. After a successful login, it should redirect you to the app where you get a response like this:
```json
{
    "status" : 200,
    "message" : "Registration successful",
    "data" : {
         "token" : "cbhgjuYTRgnkfj3647utyhkllcmnvkflpooHUY87_ouo"
     }
}
```
**Any background context you want to provide?**
- This fix was needed as the name of the hosted app was changed because of logistic reasons

**What are the relevant pivotal tracker stories?**
[#168325741](https://www.pivotaltracker.com/story/show/168325741)